### PR TITLE
feat(hashes): add hashes for little endian / .n64

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
     <script type="text/javascript">
       const KNOWN_HASHES = {
         '20b854b239203baf6c961b850a4a51a2': 'Super Mario 64 (U)',
-        '85d61f5525af708c9f1e84dce6dc10e9': 'Super Mario 64 (J)'
+        '85d61f5525af708c9f1e84dce6dc10e9': 'Super Mario 64 (J)',
+        '165a9558b7539507e73e7afecffb200c': 'Super Mario 64 (U)',
+        '73c72657b1320faf2a6aea0e0a3de45a': 'Super Mario 64 (J)'
       };
 
       let mainDiv;


### PR DESCRIPTION
add hashes for little endian / .n64 roms. if you take a rom with either of these hashes, and convert it into .z64 using [this tool](https://hack64.net/tools/swapper.php), they match the hashes currently deemed valid.